### PR TITLE
One last (hopefully!) edit to bibliography

### DIFF
--- a/JOSS_submission/paper.bib
+++ b/JOSS_submission/paper.bib
@@ -183,7 +183,7 @@ archivePrefix = {arXiv},
 }
 
 @Article{AIReview,
-    AUTHOR = {Renzini, A. I. and Goncharov, B. and Jenkins, A. C. and Meyers, P. M.},
+    AUTHOR = {{Renzini}, Arianna I. and Goncharov, B. and Jenkins, A. C. and Meyers, P. M.},
     TITLE = {Stochastic Gravitational-Wave Backgrounds: Current Detection Efforts and Future Prospects},
     JOURNAL = {Galaxies},
     VOLUME = {10},


### PR DESCRIPTION
Sorry I missed this one before. Our citation format can't disambiguate initials and full names so we need the first authors to always have consistent typesetting in the bib file.

https://github.com/openjournals/joss-reviews/issues/5454